### PR TITLE
Allow OpenAI compatible model providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,19 @@ A developer-friendly Lua interface for working with various generative AI provid
 
 ### Providers
 
-- [OpenAI](https://platform.openai.com/docs/overview)
+- OpenAI: https://platform.openai.com/docs/overview
 
-- [Anthropic](https://docs.anthropic.com/en/home)
+- Anthropic: https://docs.anthropic.com/en/home
+
+- Anything OpenAI compatible e.g. **Perplexity, Together AI, etc.** by prefixing endpoint with openai and double colon: `"openai::https://api.perplexity.ai/chat/completions"`
 
 ### Roadmap
 
-1. Advanced error handling
-2. Google Gemini integration
-3. Audio models
-4. Image models
-5. Open-Source model integration
-6. Video models
+- [ ] Audio models
+
+- [ ] Image models
+
+- [ ] Video models
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A developer-friendly Lua interface for working with various generative AI provid
 - Stream output for real-time responses
 - Structured JSON response abstraction layer
 - Token usage tracking with cost calculation
+- Open-source models via OpenAI compatibility
 
 ### Providers
 

--- a/src/genai/genai.lua
+++ b/src/genai/genai.lua
@@ -41,7 +41,6 @@ end
 ---@return string endpoint
 function GenAI:check_if_openai_compatible(endpoint)
 	local prefix, url = endpoint:match("^(.-)::(.+)$")
-	print(url)
 	return (prefix == "openai") and url or endpoint
 end
 

--- a/src/genai/genai.lua
+++ b/src/genai/genai.lua
@@ -27,11 +27,22 @@ end
 ---@return table? provider_module Collection of functions determining input and output structure
 function GenAI:_determine_provider(providers)
 	local provider = nil
+	local endpoint = self._endpoint
 	for provider_name, provider_module in pairs(providers) do
-		if self._endpoint:find(provider_name) then provider = provider_module end
+		if endpoint:find(provider_name) then provider = provider_module end
 	end
 	assert(provider, "GenAI provider could not be determined from provided endpoint")
+	self._endpoint = self:check_if_openai_compatible(endpoint)
 	return provider
+end
+
+---Check if the endpoint starts with 'openai::' for API compatibility
+---@param endpoint string
+---@return string endpoint
+function GenAI:check_if_openai_compatible(endpoint)
+	local prefix, url = endpoint:match("^(.-)::(.+)$")
+	print(url)
+	return (prefix == "openai") and url or endpoint
 end
 
 ---Prepare streaming requirements if set to stream


### PR DESCRIPTION
Parse provider string and check for double colon and prefix.

e.g. `"openai::https://api.perplexity.ai/chat/completions"`

This allows open-source model integration.