### PR TITLE
Coroutine based non-blocking async requests via copas

### DIFF
--- a/rockspecs/lua-genai-0.3-1.rockspec
+++ b/rockspecs/lua-genai-0.3-1.rockspec
@@ -1,0 +1,29 @@
+package = "lua-genai"
+version = "0.3-1"
+source = {
+   url = "https://github.com/emilrueh/lua-genai/archive/refs/tags/v0.3.tar.gz"
+}
+description = {
+   summary = "Generative AI SDK",
+   detailed = "Interface for generative AI providers like OpenAI, Anthropic, Google Gemini, DeepSeek, etc. abstracting away provider-specific payload structures and response parsing to simplify switching models with optional async requests.",
+   homepage = "https://github.com/emilrueh/lua-genai",
+   license = "Zlib"
+}
+dependencies = {
+   "lua >= 5.1",
+   "lua-cjson",
+   "luasec"
+}
+build = {
+   type = "builtin",
+   modules = {
+      genai = "src/genai/init.lua",
+      ["genai.features"] = "src/genai/features/init.lua",
+      ["genai.features.chat"] = "src/genai/features/chat.lua",
+      ["genai.genai"] = "src/genai/genai.lua",
+      ["genai.providers"] = "src/genai/providers/init.lua",
+      ["genai.providers.anthropic"] = "src/genai/providers/anthropic.lua",
+      ["genai.providers.openai"] = "src/genai/providers/openai.lua",
+      ["genai.utils"] = "src/genai/utils.lua"
+   }
+}

--- a/src/genai/utils.lua
+++ b/src/genai/utils.lua
@@ -11,8 +11,8 @@ local utils = {}
 ---@return number response
 ---@return number status
 ---@return table headers
-local function _exec_request(opts)
-	if copas.running then return copas.http.request(opts) end
+local function _exec_request(opts, async)
+	if async then return copas.http.request(opts) end
 	return ssl_https.request(opts)
 end
 
@@ -24,7 +24,7 @@ end
 ---@param callback function?
 ---@param exception_handler function?
 ---@return string|table body
-function utils.send_request(url, payload, method, headers, callback, exception_handler)
+function utils.send_request(url, payload, method, headers, callback, exception_handler, async)
 	local response_body = {}
 	local final_sink = ltn12.sink.table(response_body)
 
@@ -46,7 +46,7 @@ function utils.send_request(url, payload, method, headers, callback, exception_h
 		source = payload and ltn12.source.string(payload) or nil,
 	}
 
-	local _, status_code, response_headers = _exec_request(request_opts)
+	local _, status_code, response_headers = _exec_request(request_opts, async)
 	local body = table.concat(response_body)
 
 	-- decode body if json response


### PR DESCRIPTION
- new flag defaults to `async = false` to call ssl.https or copas.http